### PR TITLE
docs: add components and hooks section for routes

### DIFF
--- a/docs/guides/routes.md
+++ b/docs/guides/routes.md
@@ -344,3 +344,203 @@ The included helpers are:
 - `res.redirect([status,] path)` - Redirects to a specified path or URL. `status` must be a valid [HTTP status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes). If not specified, `status` defaults to "307" "Temporary redirect".
 
 > Notice: api.js and page.js are conflicting, when both exist, only page.js will be enabled.
+
+
+## Router components
+
+### `<Link>`
+
+This component renders an anchor tag and is the primary way the user will navigate around your website. Anywhere you would have used `<a href="...">` you should now use `<Link to="..."/>` to get all the performance benefits of client-side routing in Shuvi.
+
+#### Props
+
+```ts
+interface LinkProps
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+  to: PathRecord;
+
+  // route.push or route.replace
+  replace?: boolean;
+
+  state?: State;
+
+  // default to true, whether to prefetch resource
+  prefetch?: boolean;
+}
+```
+
+#### Example
+
+```tsx
+import { Link } from "@shuvi/runtime";
+
+export default function Navigation() {
+  return (
+    <nav>
+      <Link to="/home">Home</Link>
+      <Link to="/about">about</Link>
+    </nav>
+  );
+}
+```
+
+
+### `<RouterView>`
+
+Component to display the current route the user is at.
+
+#### Example
+
+With the following routes definition:
+
+```ts
+export const routes = [
+  {
+    path: "users",
+    component: "Users",
+    children: [
+      {
+        path: ":userId",
+        component: "UserDetail",
+      },
+    ],
+  },
+];
+```
+
+```tsx
+function App() {
+  return (
+    <div>
+      <h1>App</h1>
+      <Router>
+        // this will render Users component
+        <Outlet /> 
+      <Router>
+    </div>
+  );
+}
+
+function Users() {
+  return (
+    <div>
+      <h1>Users</h1>
+      // this will render UserDetail component
+      <Outlet />
+    </div>
+  );
+}
+```
+
+## Router hooks
+
+
+### useLoaderData
+
+This hook returns the JSON parsed data from your route loader function.
+
+#### Example
+
+```tsx
+import { useLoaderData } from "@shuvi/runtime";
+
+export async function loader() {
+  return fetchUserDetail();
+}
+
+export default function UserProfile() {
+  const userInfo = useLoaderData();
+  // ...
+}
+```
+
+### useParams
+
+The `useParams` hook returns an object of key/value pairs of the dynamic params from the current URL that were matched by the `route.path`. Child routes inherit all params from their parent routes.
+
+#### Type
+
+```ts
+function useParams<T extends {} = {}>(): Readonly<T>;
+```
+
+#### Example
+
+```tsx
+import * as React from "react";
+import { Routes, Route, useParams } from "react-router-dom";
+
+function ProfilePage() {
+  // Get the userId param from the URL.
+  let { userId } = useParams();
+  // ...
+}
+
+function App() {
+  return (
+    <Router
+      routes={[
+        {
+          path: "users",
+          children: [
+            {
+              path: ":userId",
+              componnet: ProfilePage,
+            },
+            {
+              path: "me",
+            },
+          ],
+        },
+      ]}
+    ></Router>
+  );
+}
+```
+
+### useCurrentRoute
+
+Return the matched route with the current URL.
+
+#### Type
+
+```ts
+function useCurrentRoute(): import("@shuvi/router").IRoute<{
+  path: string;
+  component?: any;
+  children?: any[] | undefined;
+  props?: object;
+  redirect?: string | undefined;
+}>;
+```
+
+### useRouter
+
+Return `router` instance.
+
+#### Type
+
+```tsx
+interface IRouter<
+  RouteRecord extends {
+    path: string;
+  } = any
+> {
+  push(to: PathRecord, state?: any): void;
+  replace(to: PathRecord, state?: any): void;
+  go: History["go"];
+  back: History["back"];
+  block: History["block"];
+  resolve: History["resolve"];
+  forward(): void;
+  routes: RouteRecord[];
+  match(to: PathRecord): Array<IRouteMatch<RouteRecord>>;
+  listen: (listener: Listener) => RemoveListenerCallback;
+  beforeEach: (listener: NavigationGuardHook) => RemoveListenerCallback;
+  beforeResolve: (listener: NavigationGuardHook) => RemoveListenerCallback;
+  afterEach: (listener: NavigationResolvedHook) => RemoveListenerCallback;
+}
+
+function useRouter(): IRouter;
+```
+


### PR DESCRIPTION
Happy Chinese New Year, guys!
The pull request is open for upgrade the components and hooks section into the `guides/routes` page. After it merged, we can find everything about the routes, here: https://shuvijs.github.io/shuvijs.org/docs/guides/Routes.

About my previously reading style, click here: https://umijs.org/docs/guides/routes
